### PR TITLE
Fix tests by mocking IntersectionObserver

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,10 @@ class App extends Component {
     } else if (pickedLanguage === window.$tertiaryLanguage) {
       pickedLangIconId = window.$tertiaryLanguageIconId;
     }
-    document.getElementById(pickedLangIconId).style.filter = "brightness(100%)";
+    const elem = document.getElementById(pickedLangIconId);
+    if (elem) {
+      elem.style.filter = "brightness(100%)";
+    }
   }
 
   componentDidMount() {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import ReactDOM from 'react-dom';
 import App from './App';
 
 it('renders without crashing', () => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,13 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+
+// Mock IntersectionObserver for tests
+class IntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.IntersectionObserver = IntersectionObserver;


### PR DESCRIPTION
## Summary
- add safety check in `swapCurrentlyActiveLanguage`
- import ReactDOM in test
- polyfill `IntersectionObserver` in Jest setup

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840c8b63f148322b85688aca74c12db